### PR TITLE
fix!: Make the package work with the plan object

### DIFF
--- a/main.star
+++ b/main.star
@@ -4,14 +4,14 @@ helpers = import_module('github.com/kurtosis-tech/datastore-army-package/src/hel
 PACKAGE_NAME_FOR_LOGGING = "datastore-army-package"
 
 
-def run(args):
-    print("Deploying package " + PACKAGE_NAME_FOR_LOGGING + " with args: \n{0}".format(args))
+def run(plan, args):
+    plan.print("Deploying package " + PACKAGE_NAME_FOR_LOGGING + " with args: \n{0}".format(args))
     args = helpers.apply_default_to_input_args(args)
 
     if args.num_datastores == 0:
         fail("'num_datastores' is zero in package parameter. Nothing will be deployed.")
 
-    output = datastore_package.add_multiple_datastore_services(args.num_datastores)
+    output = datastore_package.add_multiple_datastore_services(plan, args.num_datastores)
 
-    print("Package " + PACKAGE_NAME_FOR_LOGGING + " successfully deployed")
+    plan.print("Package " + PACKAGE_NAME_FOR_LOGGING + " successfully deployed")
     return output

--- a/main.star
+++ b/main.star
@@ -6,7 +6,7 @@ PACKAGE_NAME_FOR_LOGGING = "datastore-army-package"
 
 def run(plan, args):
     plan.print("Deploying package " + PACKAGE_NAME_FOR_LOGGING + " with args: \n{0}".format(args))
-    args = helpers.apply_default_to_input_args(args)
+    args = helpers.apply_default_to_input_args(plan, args)
 
     if args.num_datastores == 0:
         fail("'num_datastores' is zero in package parameter. Nothing will be deployed.")

--- a/src/datastore-army-package.star
+++ b/src/datastore-army-package.star
@@ -8,7 +8,7 @@ SERVICE_ID_PREFIX = "datastore-"
 
 
 def add_datastore_service(plan, unique_service_id):
-    print("Adding service " + unique_service_id)
+    plan.print("Adding service " + unique_service_id)
 
     service_config = struct(
         image = DATASTORE_IMAGE,

--- a/src/datastore-army-package.star
+++ b/src/datastore-army-package.star
@@ -7,7 +7,7 @@ DATASTORE_TRANSPORT_PROTOCOL = "TCP"
 SERVICE_ID_PREFIX = "datastore-"
 
 
-def add_datastore_service(unique_service_id):
+def add_datastore_service(plan, unique_service_id):
     print("Adding service " + unique_service_id)
 
     service_config = struct(
@@ -16,13 +16,13 @@ def add_datastore_service(unique_service_id):
             DATASTORE_PORT_ID: PortSpec(number = DATASTORE_PORT_NUMBER, transport_protocol = DATASTORE_TRANSPORT_PROTOCOL)
         }
     )
-    add_service(service_id = unique_service_id, config = service_config)
+    plan.add_service(service_id = unique_service_id, config = service_config)
     return DATASTORE_PORT_ID
 
 
-def add_multiple_datastore_services(num_datastores):
+def add_multiple_datastore_services(plan, num_datastores):
     service_id_to_port_id = {}
     for index in range(num_datastores):
         service_id = SERVICE_ID_PREFIX + str(index)
-        service_id_to_port_id[service_id] = add_datastore_service(service_id)
+        service_id_to_port_id[service_id] = add_datastore_service(plan, service_id)
     return service_id_to_port_id

--- a/src/helpers.star
+++ b/src/helpers.star
@@ -1,10 +1,10 @@
 NUM_DATASTORES_ARG_NAME = 'num_datastores'
 DEFAULT_NUM_DATASTORES = 2
 
-def apply_default_to_input_args(input_args):
+def apply_default_to_input_args(plan, input_args):
     num_datastores = DEFAULT_NUM_DATASTORES
     if hasattr(input_args, NUM_DATASTORES_ARG_NAME):
         num_datastores = input_args.num_datastores
     else:
-        print("'{0}' not set in package args. Default value '{1}' will be applied.".format(NUM_DATASTORES_ARG_NAME, DEFAULT_NUM_DATASTORES))
+        plan.print("'{0}' not set in package args. Default value '{1}' will be applied.".format(NUM_DATASTORES_ARG_NAME, DEFAULT_NUM_DATASTORES))
     return struct(num_datastores=num_datastores)


### PR DESCRIPTION
BREAKING-CHANGE: We use the `plan` object now in datastore-army-package. Users must upgrade to Kurtosis >= 0.63 and restart the engine for this to work.