### PR TITLE
fix: removed service_id parameter name to break service_name change deadlock

### DIFF
--- a/src/datastore-army-package.star
+++ b/src/datastore-army-package.star
@@ -16,7 +16,8 @@ def add_datastore_service(plan, unique_service_id):
             DATASTORE_PORT_ID: PortSpec(number = DATASTORE_PORT_NUMBER, transport_protocol = DATASTORE_TRANSPORT_PROTOCOL)
         }
     )
-    plan.add_service(service_id = unique_service_id, config = service_config)
+    # TODO name the service_name argument after the new version gets out
+    plan.add_service(unique_service_id, config = service_config)
     return DATASTORE_PORT_ID
 
 


### PR DESCRIPTION
I cant make this change backwards compatible, as the service_id is the first parameter, and config the other. If I do

add_service(service_name?, service_id?, config) -> this isnt valid starlark
add_service(service_name?, service_id?, config?) -> positional usage breaks
add_service(config?, service_name?, service_id?) -> positional usage breaks as well