### PR TITLE
refactor: Use args as dict instead of struct

### DIFF
--- a/main.star
+++ b/main.star
@@ -11,7 +11,7 @@ def run(plan, args):
     if args.num_datastores == 0:
         fail("'num_datastores' is zero in package parameter. Nothing will be deployed.")
 
-    output = datastore_package.add_multiple_datastore_services(plan, args.num_datastores, args.parallel)
+    output = datastore_package.add_multiple_datastore_services(plan, args["num_datastores"], args["parallel"])
 
     plan.print("Package " + PACKAGE_NAME_FOR_LOGGING + " successfully deployed")
     return output

--- a/main.star
+++ b/main.star
@@ -11,7 +11,7 @@ def run(plan, args):
     if args.num_datastores == 0:
         fail("'num_datastores' is zero in package parameter. Nothing will be deployed.")
 
-    output = datastore_package.add_multiple_datastore_services(plan, args["num_datastores"], args["parallel"])
+    output = datastore_package.add_multiple_datastore_services(plan, args.num_datastores, args.parallel)
 
     plan.print("Package " + PACKAGE_NAME_FOR_LOGGING + " successfully deployed")
     return output

--- a/src/helpers.star
+++ b/src/helpers.star
@@ -4,14 +4,14 @@ DEFAULT_NUM_DATASTORES = 2
 
 def apply_default_to_input_args(plan, input_args):
     num_datastores = DEFAULT_NUM_DATASTORES
-    if hasattr(input_args, NUM_DATASTORES_ARG_NAME):
-        num_datastores = input_args.num_datastores
+    if NUM_DATASTORES_ARG_NAME in input_args:
+        num_datastores = input_args[NUM_DATASTORES_ARG_NAME]
     else:
         plan.print("'{0}' not set in package args. Default value '{1}' will be applied.".format(NUM_DATASTORES_ARG_NAME, DEFAULT_NUM_DATASTORES))
 
     parallel = False
-    if hasattr(input_args, PARALLEL_ARG_NAME):
-        parallel = input_args.parallel
+    if PARALLEL_ARG_NAME in input_args:
+        parallel = input_args["PARALLEL_ARG_NAME"]
     else:
         plan.print("'{0}' not set in package args. Services will be added sequentially.".format(PARALLEL_ARG_NAME))
 


### PR DESCRIPTION
Changelog picked up from commits here:

refactor: Use args as dict instead of struct